### PR TITLE
Added retrieve function for updating categories

### DIFF
--- a/rareapi/views/categories.py
+++ b/rareapi/views/categories.py
@@ -22,6 +22,23 @@ class Categories(ViewSet):
         except ValidationError as ex:
             return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
 
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single Category
+        Returns:
+            Response -- JSON serialized Category instance
+        """
+        try:
+            # `pk` is a parameter to this function, and
+            # Django parses it from the URL route parameter
+            #   http://localhost:8000/categories/2
+            #
+            # The `2` at the end of the route becomes `pk`
+            post = Category.objects.get(pk=pk)
+            serializer = CategorySerializer(post, context={'request': request})
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
     def list(self, request):
         categories = Category.objects.all()
 


### PR DESCRIPTION
# Edit a Category
## https://github.com/nss-day-cohort-44/rare-rest-malicious-vortices-client/issues/17


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions
`git fetch origin ts-edit-categories`
`git checkout ts-edit-categories` 

User Instructions: 
Test PUT request via Postman. The expected outcome is that you can modify the `label` field of a specified category.

Postman Example: 
URL: `http://localhost:8000/categories/10` 
Body:
```
{
    "label": "Updated Rust"
}
```
Expected Result of GET:
```
{
        "id": 10,
        "label": "Updated Rust"
}
```

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new errors
- [X] I have added test instructions that prove my fix is effective or that my feature works